### PR TITLE
use border-collapse instead of first-row class

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -272,24 +272,17 @@ header .title{
      width: 850px;
      border-spacing: 0;
      margin: 0;
-     border-left: 1px solid #000;
+     border: 1px solid #000;
+     border-collapse: collapse;
  }
 
  .table-area td,
  .table-area th
  {
-    width: 85px;
-    height: 30px;
-    font-weight: normal;
-    border-right:1px solid #000;
-    border-bottom:1px solid #000;
- }
-
- .first-row td,
- .first-row th
- {
-     border:1px solid #000;
-     border-left-color: transparent;
+     width: 85px;
+     height: 30px;
+     font-weight: normal;
+     border: 1px solid #000;
  }
 
  .table-area th{

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
             <section class="prefecture">
                 <div class="prefecture-table">
                     <table class="table-area">
-                        <tr class="first-row">
+                        <tr>
                             <th>都道府県名<th>感染者数</th><td></td><td></td><td></td><td></td>
                         </tr>
                         <tr>


### PR DESCRIPTION
I figured out that we can simply avoid bold border in case that overlapping table cells by using `border-collapse` property.