### PR TITLE
グラフ表示周りの修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -410,18 +410,27 @@ header .title{
  * detail
  * -------------------------------- */
 
- .detail-graph{
+.detail {
      margin: 5px 0 10px;
      width: 1020px;
      height: 600px;
      border: 1px solid #8fd3f4;
      border-radius: 2%;
+}
+
+ .detail .graph{
+     margin: 5px 0 10px;
  }
 
- .graph-title{
+ .detail .graph .title{
     font-weight: bold;
-    font-size: 2.5rem;
-    margin-left: 20px;
+    font-size: 2.0rem;
+    margin-left: 25px;
+ }
+
+ .detail .graph .chart {
+   height: 500px;
+   margin: 10px;
  }
 
    /* --------------------------------

--- a/index.html
+++ b/index.html
@@ -282,8 +282,9 @@
                 </div>
             </section>
             <section class="detail">
-                <div class="detail-graph" id="detail-graph">
-                    <p class="graph-title">東京都 5月16日(木)</p>
+                <div class="graph">
+                  <p id="detail-graph-title" class="title">東京都の日別発生状況</p>
+                  <div id="detail-graph" class="chart"></div>
                 </div>
             </section>
         </div>

--- a/js/package.json
+++ b/js/package.json
@@ -10,6 +10,7 @@
     "moment": "^2.25.3"
   },
   "devDependencies": {
+    "beautify-css": "^1.0.0",
     "copy-webpack-plugin": "^6.0.1",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/js/src/App.js
+++ b/js/src/App.js
@@ -65,6 +65,8 @@ export class App {
             that.prefStats.render(infectionInfo[index]);
             // 詳細グラフの更新
             that.prefGraph.update(infectionInfo[index].daily);
+            let prefGrapTitle = document.querySelector(`detail-graph-title`);
+            prefGraphTitle.innerHTML = `${info.name}の日別発生状況`;
           });
           // 地図の表示
           map.render();
@@ -87,6 +89,8 @@ export class App {
                 that.prefStats.render(info);
                 // 詳細グラフの更新
                 that.prefGraph.update(info.daily);
+                let prefGraphTitle = document.querySelector('#detail-graph-title');
+                prefGraphTitle.innerHTML = `${info.name}の日別発生状況`;
               }
             });
         }

--- a/js/src/components/InfectionGraph.js
+++ b/js/src/components/InfectionGraph.js
@@ -67,7 +67,7 @@ export class InfectionGraph {
 
     let infection = this.chart.series.push(new am4charts.LineSeries());
     infection.dataFields.dateX = "reported_date";
-    infection.name = "感染者数";
+    infection.name = "現在感染者数";
     infection.dataFields.valueY = "current_infected";
     infection.tooltipHTML = "<span style='font-size:14px; color:#000000;'>感染者数:<b>{valueY.value}</b></span>";
     infection.tooltipText = "[#000]{valueY.value}[/]";


### PR DESCRIPTION
- グラフのタイトル（`東京都の日別感染状況`）の更新
- グラフの凡例`感染者数`を`現在感染者数`に変更