### PR TITLE
背景の三角形のサイズをbodyに合わせて調整

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -20,7 +20,7 @@ body {
 .triangle.a {
   position: absolute;
   top: 0;
-  width: 1120px;
+  width: 100%;
   height: 500px;
   background-image: linear-gradient(120deg, #84fab0 0%, #8fd3f4 100%);
   z-index: -2;
@@ -30,6 +30,8 @@ body {
   content: '';
   position: absolute;
   top: 0;
+  right: 0;
+  width: 100%;
   border: 560px solid transparent;
   border-bottom-width: 250px;
   border-top-width: 250px;


### PR DESCRIPTION
一部端末でbodyよりも背景の三角形のサイズが大きくなり、画面右側に余白部分ができてしまっていたため修正。
三角形のサイズをbodyのサイズに合わせるように変更。